### PR TITLE
Avoid refcell, rework modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ name = "cikit"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atty",
  "chrono",
  "colored",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 glob = "0.3.0"
 humantime = "2.0"
 colored = "1.9"
+atty = "0.2"
 
 [dev-dependencies]
 uuid =  { version = "0.8", features = ["serde", "v4"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,12 +32,9 @@ impl Config {
 }
 
 mod tests {
-    use super::*;
-    use crate::github::GithubHandle;
-    use crate::slack::SlackUserId;
-
     #[test]
     fn parse_from_toml() {
+        use super::*;
         let config: Config = toml::from_str(
             r#"
         [notifications]

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,5 @@
 use crate::junit::{HasOutcome, TestOutcome};
-use colored::{ColoredString, Colorize};
+use colored::{Color, ColoredString, Colorize};
 use io::Result;
 use std::io;
 
@@ -7,6 +7,13 @@ use crate::{junit::*, notify::Notifier};
 
 const INDENT_STR: &str = " ";
 
+fn color_if_pos<S: Into<Color>>(value: usize, color: S) -> ColoredString {
+    if value > 0 {
+        value.to_string().color(color)
+    } else {
+        value.to_string().normal()
+    }
+}
 pub trait ConsoleDisplay {
     fn display(&self, f: &mut Box<dyn io::Write>, depth: usize) -> Result<()>;
 }
@@ -15,15 +22,29 @@ impl ConsoleDisplay for Summary {
     fn display(&self, f: &mut Box<dyn io::Write>, _depth: usize) -> Result<()> {
         writeln!(
             f,
-            "> {:<20}:{}",
+            "> {:<11}:{}",
             "Duration",
             display::duration(self.total_time.to_std().unwrap())
         )?;
-        writeln!(f, "> {:<20}:{:<4}", "Tests run", self.tests)?;
-        writeln!(f, "> {:<20}:{:<4}", "Falures", self.failures)?;
-        writeln!(f, "> {:<20}:{:<4}", "Errors", self.errors)?;
-        writeln!(f, "> {:<20}:{:<4}", "Skipped", self.errors)?;
-        writeln!(f, "")
+        writeln!(f, "> {:<11}:{:<4}", "Tests run", self.tests)?;
+        writeln!(
+            f,
+            "> {:<11}:{:<4}",
+            "Falures",
+            color_if_pos(self.failures, Color::Red)
+        )?;
+        writeln!(
+            f,
+            "> {:<11}:{:<4}",
+            "Errors",
+            color_if_pos(self.errors, Color::Red)
+        )?;
+        writeln!(
+            f,
+            "> {:<11}:{:<4}",
+            "Skipped",
+            color_if_pos(self.errors, Color::Blue)
+        )
     }
 }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -49,7 +49,6 @@ mod tests {
     extern crate pretty_assertions;
 
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn deserialize_from_github_event() {

--- a/src/junit/cli.rs
+++ b/src/junit/cli.rs
@@ -1,0 +1,43 @@
+use std::str::FromStr;
+use structopt::StructOpt;
+#[derive(Debug, PartialEq, StructOpt)]
+pub enum SortingOrder {
+    Asc,
+    Desc,
+}
+
+impl FromStr for SortingOrder {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match &*s.to_uppercase() {
+            "ASC" => Ok(SortingOrder::Asc),
+            "DESC" => Ok(SortingOrder::Desc),
+            _ => Err(anyhow::Error::msg(format!(
+                "Cannot parse `SortingOrder`, invalid token {}",
+                s
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub enum ReportSorting {
+    Time(SortingOrder),
+}
+impl FromStr for ReportSorting {
+    type Err = anyhow::Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let chunks: Vec<&str> = s.split(" ").take(2).collect();
+        if chunks.len() == 1 && chunks[0].to_lowercase() == "time" {
+            Ok(ReportSorting::Time(SortingOrder::Desc))
+        } else if chunks.len() == 2 && chunks[0].to_lowercase() == "time" {
+            let order = SortingOrder::from_str(chunks[1])?;
+            Ok(ReportSorting::Time(order))
+        } else {
+            Err(anyhow::Error::msg(format!(
+                "Cannot parse `SortingOrder`, invalid token {}",
+                s
+            )))
+        }
+    }
+}

--- a/src/junit/fs.rs
+++ b/src/junit/fs.rs
@@ -1,0 +1,95 @@
+use super::{read_suite, Summary, TestSuite};
+use anyhow::Result;
+use glob::{glob_with, MatchOptions};
+use log::debug;
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+struct ReportVisitor {
+    report_files: Vec<PathBuf>,
+    position: usize,
+}
+
+impl ReportVisitor {
+    pub fn from_basedir<P: AsRef<Path>>(base_dir: P, report_dir_pattern: &str) -> Result<Self> {
+        let mut report_files: Vec<PathBuf> = Vec::new();
+        let prefixed_dir_pattern =
+            vec![base_dir.as_ref().to_str().unwrap(), report_dir_pattern].join("/");
+
+        let paths = glob_with(
+            &prefixed_dir_pattern,
+            MatchOptions {
+                case_sensitive: true,
+                require_literal_separator: true,
+                require_literal_leading_dot: true,
+            },
+        )?;
+
+        for path in paths {
+            if let Ok(path) = path {
+                if path.is_dir() {
+                    for entry in fs::read_dir(path)? {
+                        if let Ok(file) = entry {
+                            if file.path().extension() == Some(OsStr::new("xml")) {
+                                report_files.push(file.path());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!("{} report files found", report_files.len());
+
+        Ok(ReportVisitor {
+            report_files,
+            position: 0,
+        })
+    }
+}
+impl Iterator for ReportVisitor {
+    type Item = PathBuf;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.position >= self.report_files.len() {
+            None
+        } else {
+            let item = self.report_files[self.position].to_owned();
+            self.position += 1;
+            Some(item)
+        }
+    }
+}
+
+pub(super) struct TestSuiteVisitor<'s> {
+    summary: &'s mut Summary,
+    visitor: ReportVisitor,
+}
+
+impl<'s> TestSuiteVisitor<'s> {
+    pub fn from_basedir<P: AsRef<Path>>(
+        base_dir: P,
+        report_dir_pattern: &str,
+        summary: &'s mut Summary,
+    ) -> Result<Self> {
+        let visitor = ReportVisitor::from_basedir(base_dir, report_dir_pattern)?;
+        Ok(TestSuiteVisitor { visitor, summary })
+    }
+}
+impl<'s> Iterator for TestSuiteVisitor<'s> {
+    type Item = TestSuite;
+    fn next(&mut self) -> Option<Self::Item> {
+        let path = self.visitor.next()?;
+        let display_path = path.display();
+        let file = fs::File::open(path.clone())
+            .expect(&format!("Couldn't open report file: {}", display_path));
+        let suite = read_suite(file).expect(&format!(
+            "Couldn't parse junit TestSuite from XML report {}",
+            display_path
+        ));
+        self.summary.inc(&suite);
+        Some(suite)
+    }
+}

--- a/src/junit/mod.rs
+++ b/src/junit/mod.rs
@@ -122,7 +122,7 @@ pub struct FailedTestCase {
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct TestSkipped {}
 
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct Summary {
     pub total_time: Duration,
     pub tests: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate anyhow;
+extern crate atty;
 extern crate chrono;
 extern crate colored;
 extern crate glob;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use cikit::{
     console::ConsoleNotifier, github::GithubContext, notify::Notifier, slack::SlackNotifier,
 };
 
-use junit::{ReportSorting, Summary, TestSuite, TestSuiteVisitor, TestSuitesOutcome};
-use std::{env, path::PathBuf, str::FromStr};
+use junit::{ReportSorting, TestSuitesOutcome};
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -4,7 +4,7 @@ use crate::junit::{self, FailedTestSuite, Summary, TestSuitesOutcome};
 use crate::notify::Notifier;
 use serde::Deserialize;
 
-use humantime::format_duration;
+
 use std::{fmt::Display, io::Read};
 
 use log::warn;


### PR DESCRIPTION
Also, extend `TestsuiteVisitor` so that it prints build summary as it parses the testsuite files 