### PR TITLE
Parallelise Junit parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
+ "threadpool",
  "toml",
  "tree_magic",
  "uuid",
@@ -1383,6 +1384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
 thiserror = "1.0"
+threadpool = "1.8"
 toml = "0.5"
 tree_magic = "0.2"
 

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -1,17 +1,17 @@
 [notifications]
 
-[notifications.slack]
-webhook_url = "https://hooks.slack.com/services/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"
+# [notifications.slack]
+# webhook_url = "https://hooks.slack.com/services/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"
+# 
+# [notifications.slack.user_handles]
+# user_1 = "userone"
+# user_2 = "usertwo"
 
-[notifications.slack.user_handles]
-user_1 = "userone"
-user_2 = "usertwo"
-
-[notifications.google_cloud_storage]
-bucket = "cikit"
+# [notifications.google_cloud_storage]
+# bucket = "cikit"
 #creds will be read from `SERVICE_ACCOUNT` env variable
 
-[notifications.github_comments]
+# [notifications.github_comments]
 
 [junit]
 #report_dir_pattern = "**/target/test-reports/*.xml"

--- a/src/junit/mod.rs
+++ b/src/junit/mod.rs
@@ -224,21 +224,16 @@ pub fn read_testsuites(
 ) -> anyhow::Result<(Vec<SuiteWithSummary>, Summary)> {
     let current_dir = env::current_dir()?;
     let project_dir = project_dir.unwrap_or_else(|| current_dir);
-    let display_progress = true;
+    let display_progress = atty::is(atty::Stream::Stdout);
     let mut summary = Summary::zero();
 
-    let mut visitor = TestSuiteReader::from_basedir(
+    let testsuite_reader = TestSuiteReader::from_basedir(
         project_dir,
         &config.junit.report_dir_pattern,
         &mut summary,
         display_progress,
     )?;
-    // let visitor = TestSuiteVisitor::from_basedir(
-    //     project_dir,
-    //     &config.junit.report_dir_pattern,
-    //     &mut summary,
-    // )?;
-    let test_suites: Vec<SuiteWithSummary> = visitor.all_suites();
+    let test_suites: Vec<SuiteWithSummary> = testsuite_reader.all_suites();
     Ok((test_suites, summary))
 }
 
@@ -252,44 +247,6 @@ pub fn sort_testsuites(suites: &mut Vec<SuiteWithSummary>, sorting: &ReportSorti
         }
     });
 }
-
-// pub enum TestSuitesOutcome {
-//     Success(Summary),
-//     Failure {
-//         summary: Summary,
-//         failed_testsuites: Vec<FailedTestSuite>,
-//     },
-// }
-// impl TestSuitesOutcome {
-//     pub fn new(summary: Summary, suites: Vec<SuiteWithSummary>) -> Self {
-//         if summary.is_successful() {
-//             TestSuitesOutcome::Success(summary)
-//         } else {
-//             let failed_testsuites = suites
-//                 .into_iter()
-//                 .filter_map(|s| s.value.as_failed())
-//                 .map(|s| s.value)
-//                 .collect::<Vec<_>>();
-
-//             TestSuitesOutcome::Failure {
-//                 summary,
-//                 failed_testsuites,
-//             }
-//         }
-//     }
-//     pub fn summary(&self) -> &Summary {
-//         match self {
-//             TestSuitesOutcome::Success(summary) => summary,
-//             TestSuitesOutcome::Failure { summary, .. } => summary,
-//         }
-//     }
-//     pub fn is_successful(&self) -> bool {
-//         match self {
-//             TestSuitesOutcome::Success(_) => true,
-//             _ => false,
-//         }
-//     }
-// }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -590,7 +547,7 @@ com.example
         create_report_dir(base_dir, "testreports", 3, 3, 7).expect("Couldn't setup test data");
         let mut summary = Summary::zero();
 
-        let mut reader =
+        let reader =
             TestSuiteReader::from_basedir(base_dir, report_dir_pattern, &mut summary, false)
                 .expect("Couldn't initialise the testsuite reader");
 

--- a/src/junit/mod.rs
+++ b/src/junit/mod.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use serdes::*;
 use std::{env, io, ops::AddAssign, path::PathBuf};
 
+use self::fs::ParTestSuiteVisitor;
+
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub struct SummaryWith<T>
 where
@@ -223,13 +225,14 @@ pub fn read_testsuites(
 ) -> anyhow::Result<(Vec<SuiteWithSummary>, Summary)> {
     let current_dir = env::current_dir()?;
     let project_dir = project_dir.unwrap_or_else(|| current_dir);
-    let mut summary = Summary::zero();
-    let visitor = TestSuiteVisitor::from_basedir(
-        project_dir,
-        &config.junit.report_dir_pattern,
-        &mut summary,
-    )?;
-    let test_suites: Vec<SuiteWithSummary> = visitor.collect();
+    let summary = Summary::zero();
+    let visitor = ParTestSuiteVisitor::from_basedir(project_dir, &config.junit.report_dir_pattern)?;
+    // let visitor = TestSuiteVisitor::from_basedir(
+    //     project_dir,
+    //     &config.junit.report_dir_pattern,
+    //     &mut summary,
+    // )?;
+    let test_suites: Vec<SuiteWithSummary> = visitor.all_suites();
     Ok((test_suites, summary))
 }
 


### PR DESCRIPTION
Rework Junit suite loading by reading and parsing of XML files through a threadpool feeding results back via a channel. This brings a performance improvement noticeable even when using only a handful of threads (from ~60 to ~20 seconds for parsing a suite of ~150 files) which should make the tool a bit more snappy and responsive. 